### PR TITLE
Add *.pyc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.pyc
 /build
 /dist
 MANIFEST


### PR DESCRIPTION
Without this, if you have hiredis-py in a submodule, when you run 'python setup.py build', it generates an unignored 'version.pyc' which causes the submodule in the parent repo to be marked dirty by git.
