### PR TITLE
Update gitsubmodule to the correct repo.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/hiredis"]
 	path = vendor/hiredis
-	url = git://github.com/antirez/hiredis.git
+	url = git://github.com/redis/hiredis.git


### PR DESCRIPTION
The hiredis submodule moved to https://github.com/redis/hiredis.git.
This change fixes the submodule.
