### PR TITLE
Mem leak when using callables that reference an instance

### DIFF
--- a/src/reader.c
+++ b/src/reader.c
@@ -156,6 +156,8 @@ static void Reader_dealloc(hiredis_ReaderObject *self) {
     redisReplyReaderFree(self->reader);
     if (self->encoding)
         free(self->encoding);
+    Py_XDECREF(self->protocolErrorClass);
+    Py_XDECREF(self->replyErrorClass);
 
     ((PyObject *)self)->ob_type->tp_free((PyObject*)self);
 }


### PR DESCRIPTION
Without this patch this simple test will blow your memory:

``` python
import time
import hiredis

class X:
    def __init__(self):
        self.data = 'a'*1024*1024
    def error(self):
        return Exception

while True:
    x = X()
    z = hiredis.Reader(replyError=x.error)
    time.sleep(1)
```

This patch fixes a memory leak when hiredis is used in conjunction with redis-py
