### PR TITLE
Exposed hiredis maxbuf settings in python

### DIFF
--- a/src/reader.c
+++ b/src/reader.c
@@ -7,10 +7,14 @@ static int Reader_init(hiredis_ReaderObject *self, PyObject *args, PyObject *kwd
 static PyObject *Reader_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 static PyObject *Reader_feed(hiredis_ReaderObject *self, PyObject *args);
 static PyObject *Reader_gets(hiredis_ReaderObject *self);
+static PyObject *Reader_setmaxbuf(hiredis_ReaderObject *self, PyObject *arg);
+static PyObject *Reader_getmaxbuf(hiredis_ReaderObject *self);
 
 static PyMethodDef hiredis_ReaderMethods[] = {
     {"feed", (PyCFunction)Reader_feed, METH_VARARGS, NULL },
     {"gets", (PyCFunction)Reader_gets, METH_NOARGS, NULL },
+    {"setmaxbuf", (PyCFunction)Reader_setmaxbuf, METH_O, NULL },
+    {"getmaxbuf", (PyCFunction)Reader_getmaxbuf, METH_NOARGS, NULL },
     { NULL }  /* Sentinel */
 };
 
@@ -303,4 +307,28 @@ static PyObject *Reader_gets(hiredis_ReaderObject *self) {
         }
         return obj;
     }
+}
+
+static PyObject *Reader_setmaxbuf(hiredis_ReaderObject *self, PyObject *arg) {
+    long maxbuf;
+
+    if (arg == Py_None)
+        maxbuf = REDIS_READER_MAX_BUF;
+    else {
+        maxbuf = PyLong_AsLong(arg);
+        if (maxbuf < 0) {
+            if (!PyErr_Occurred())
+                PyErr_SetString(PyExc_ValueError,
+                                "maxbuf value out of range");
+            return NULL;
+        }
+    }
+    self->reader->maxbuf = maxbuf;
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyObject *Reader_getmaxbuf(hiredis_ReaderObject *self) {
+    return PyLong_FromSize_t(self->reader->maxbuf);
 }

--- a/test/reader.py
+++ b/test/reader.py
@@ -169,3 +169,13 @@ class ReaderTest(TestCase):
     if sys.hexversion >= 0x02060000:
       self.reader.feed(bytearray(b"+ok\r\n"))
       self.assertEquals(b"ok", self.reply())
+
+  def test_maxbuf(self):
+    defaultmaxbuf = self.reader.getmaxbuf()
+    self.reader.setmaxbuf(0)
+    self.assertEquals(0, self.reader.getmaxbuf())
+    self.reader.setmaxbuf(10000)
+    self.assertEquals(10000, self.reader.getmaxbuf())
+    self.reader.setmaxbuf(None)
+    self.assertEquals(defaultmaxbuf, self.reader.getmaxbuf())
+    self.assertRaises(ValueError, self.reader.setmaxbuf, -4)


### PR DESCRIPTION
This allows to change the maximum buffer size for the hiredis parser from python. Can boost speeds when handling large amounts of data.