### PR TITLE
PyPy support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,20 @@ python:
   - "3.5"
   - "pypy"
 
-install: "python setup.py develop"
+install:
+    - |
+        if [ "$TRAVIS_PYTHON_VERSION" = "pypy" ]; then
+          export PYENV_ROOT="$HOME/.pyenv"
+          if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
+            pushd "$PYENV_ROOT" && git pull && popd
+          else
+            rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
+          fi
+          export PYPY_VERSION="5.3"
+          "$PYENV_ROOT/bin/pyenv" install --skip-existing "pypy-$PYPY_VERSION"
+          virtualenv --python="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin/python" "$HOME/virtualenvs/pypy-$PYPY_VERSION"
+          source "$HOME/virtualenvs/pypy-$PYPY_VERSION/bin/activate"
+        fi
+    - "python setup.py develop"
 
 script: "python test.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "pypy"
 
-install: "python setup.py build"
+install: "python setup.py develop"
 
 script: "python test.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ install:
           virtualenv --python="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin/python" "$HOME/virtualenvs/pypy-$PYPY_VERSION"
           source "$HOME/virtualenvs/pypy-$PYPY_VERSION/bin/activate"
         fi
-    - "python setup.py develop"
+    - "pip install ."
 
 script: "python test.py"

--- a/hiredis/__init__.py
+++ b/hiredis/__init__.py
@@ -1,4 +1,9 @@
-from .hiredis import Reader, HiredisError, ProtocolError, ReplyError
+import platform
+
+if platform.python_implementation() == 'PyPy':
+  from hiredis._cffi import Reader, HiredisError, ProtocolError, ReplyError
+else:
+  from .hiredis import Reader, HiredisError, ProtocolError, ReplyError
 from .version import __version__
 
 __all__ = [

--- a/hiredis/_cffi/__init__.py
+++ b/hiredis/_cffi/__init__.py
@@ -1,0 +1,152 @@
+from hiredis._cffi._hiredis import ffi, lib
+
+
+class HiredisError(Exception):
+    pass
+
+
+class ProtocolError(HiredisError):
+    pass
+
+
+class ReplyError(HiredisError):
+    pass
+
+
+class _GlobalHandles(object):
+    def __init__(self):
+        self._handles = set()
+
+    def new(self, obj):
+        obj_id = ffi.new_handle(obj)
+        self._handles.add(obj_id)
+        return obj_id
+
+    def get(self, obj_id):
+        return ffi.from_handle(obj_id)
+
+    def free(self, obj_id):
+        obj = ffi.from_handle(obj_id)
+        self._handles.discard(obj_id)
+        return obj
+
+
+_global_handles = _GlobalHandles()
+
+
+def _parentize(task, obj):
+    if task and task.parent:
+        parent = _global_handles.get(task.parent.obj)
+        assert isinstance(parent, list)
+        parent[task.idx] = (obj)
+
+
+class Reader(object):
+    "Hiredis protocol reader"
+
+    def __init__(self, protocolError=None, replyError=None, encoding=None):
+        self._protocol_error = ProtocolError
+        self._reply_error = ReplyError
+        self._encoding = encoding or None
+
+        if protocolError:
+            if not callable(protocolError):
+                raise TypeError("Expected a callable")
+            self._protocol_error = protocolError
+
+        if replyError:
+            if not callable(replyError):
+                raise TypeError("Expected a callable")
+            self._reply_error = replyError
+
+        self._self_handle = ffi.new_handle(self)
+        self._exception = None
+
+        self._reader = lib.redisReaderCreate()
+        self._reader.privdata = self._self_handle
+        self._reader.fn.createString = self._create_string
+        self._reader.fn.createArray = self._create_array
+        self._reader.fn.createInteger = self._create_integer
+        self._reader.fn.createNil = self._create_nil
+        self._reader.fn.freeObject = self._free_object
+
+    @ffi.callback("void * (const redisReadTask*, char*, size_t)")
+    def _create_string(self, s, length):
+        self = ffi.cast("redisReadTask*", self)
+        self = ffi.from_handle(self.privdata)
+        data = ffi.string(s, length)
+        if self.type == lib.REDIS_REPLY_ERROR:
+            data = self._reply_error(data)
+        elif self._encoding is not None:
+            try:
+                data = data.decode(self._encoding)
+            except ValueError:
+                # for compatibility with hiredis
+                pass
+            except Exception as err:
+                self._exception = err
+                data = None
+        _parentize(self, data)
+        return _global_handles.new(data)
+
+    @ffi.callback("void *(const redisReadTask*, int)")
+    def _create_array(self, i):
+        self = ffi.cast("redisReadTask*", self)
+        data = [None] * i
+        _parentize(self, data)
+        return _global_handles.new(data)
+
+    @ffi.callback("void *(const redisReadTask*, long long)")
+    def _create_integer(self, n):
+        self = ffi.cast("redisReadTask*", self)
+        data = n
+        _parentize(self, data)
+        return _global_handles.new(data)
+
+    @ffi.callback("void *(const redisReadTask*)")
+    def _create_nil(self):
+        self = ffi.cast("redisReadTask*", self)
+        data = None
+        _parentize(self, data)
+        return _global_handles.new(data)
+
+    @ffi.callback("void (void*)")
+    def _free_object(self):
+        _global_handles.free(self)
+
+    def feed(self, buf, offset=None, length=None):
+        if offset is None:
+            offset = 0
+        if length is None:
+            length = len(buf) - offset
+
+        if offset < 0 or length < 0:
+            raise ValueError("negative input")
+
+        if offset + length > len(buf):
+            raise ValueError("input is larger than buffer size")
+
+        if isinstance(buf, bytearray):
+            c_buf = ffi.new("char[]", length)
+            for i in range(length):
+                c_buf[i] = chr(buf[offset + i])
+        else:
+            c_buf = ffi.new("char[]", buf[offset:offset + length])
+        lib.redisReaderFeed(self._reader, c_buf, length)
+
+    def gets(self):
+        reply = ffi.new("void **")
+        result = lib.redisReaderGetReply(self._reader, reply)
+
+        if result != lib.REDIS_OK:
+            errstr = ffi.string(self._reader.errstr)
+            raise self._protocol_error(errstr)
+
+        if reply[0] == ffi.NULL:
+            return False
+
+        if self._exception:
+            err, self._exception = self._exception, None
+            raise err
+
+        return _global_handles.free(reply[0])

--- a/hiredis/_cffi/__init__.py
+++ b/hiredis/_cffi/__init__.py
@@ -48,7 +48,7 @@ def _parentize(task, obj):
     if task and task.parent:
         parent = _global_handles.get(task.parent.obj)
         assert isinstance(parent, list)
-        parent[task.idx] = (obj)
+        parent[task.idx] = obj
 
 
 @ffi.def_extern()

--- a/hiredis/_cffi/__init__.py
+++ b/hiredis/_cffi/__init__.py
@@ -1,7 +1,13 @@
+from sys import version_info
+
 from hiredis._cffi._hiredis import ffi, lib
 
 REDIS_READER_MAX_BUF = 1024 * 16
 
+if version_info[0] == 3:
+    int_type = int
+else:
+    int_type = long
 
 class HiredisError(Exception):
     pass
@@ -101,7 +107,7 @@ class Reader(object):
     @ffi.callback("void *(redisReadTask*, long long)")
     def _create_integer(task, n):
         task = ffi.cast("redisReadTask*", task)
-        data = n
+        data = int_type(n)
         _parentize(task, data)
         return _global_handles.new(data)
 

--- a/hiredis/hiredis_build.py
+++ b/hiredis/hiredis_build.py
@@ -50,6 +50,12 @@ redisReader *redisReaderCreate(void);
 void redisReaderFree(redisReader *r);
 int redisReaderFeed(redisReader *r, const char *buf, size_t len);
 int redisReaderGetReply(redisReader *r, void **reply);
+
+extern "Python" void *create_string(const redisReadTask*, char*, size_t);
+extern "Python" void *create_array(const redisReadTask*, int);
+extern "Python" void *create_integer(const redisReadTask*, long long);
+extern "Python" void *create_nil(const redisReadTask*);
+extern "Python" void free_object(void*);
 """)
 
 c_files = ['read', 'sds', 'hiredis', 'net']

--- a/hiredis/hiredis_build.py
+++ b/hiredis/hiredis_build.py
@@ -1,0 +1,58 @@
+import os
+from cffi import FFI
+
+try:
+    from setuptools import setup, Extension
+    from setuptools.command import install_lib as _install_lib
+except ImportError:
+    from distutils.core import setup, Extension
+    from distutils.command import install_lib as _install_lib
+
+vendored_hiredis = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../vendor/hiredis')
+
+ffi = FFI()
+
+ffi.cdef("""
+#define REDIS_OK ...
+#define REDIS_ERR ...
+#define REDIS_REPLY_ERROR ...
+
+typedef struct redisReadTask {
+    int type;
+    int elements;
+    int idx;
+    void *obj;
+    struct redisReadTask *parent;
+void *privdata;
+} redisReadTask;
+
+typedef struct redisReplyObjectFunctions {
+    void *(*createString)(const redisReadTask*, char*, size_t);
+    void *(*createArray)(const redisReadTask*, int);
+    void *(*createInteger)(const redisReadTask*, long long);
+    void *(*createNil)(const redisReadTask*);
+    void (*freeObject)(void*);
+} redisReplyObjectFunctions;
+
+typedef struct redisReader {
+    int err;
+    char errstr[...];
+    redisReplyObjectFunctions *fn;
+    void *privdata;
+    ...;
+} redisReader;
+
+redisReader *redisReaderCreate(void);
+void redisReaderFree(redisReader *r);
+int redisReaderFeed(redisReader *r, const char *buf, size_t len);
+int redisReaderGetReply(redisReader *r, void **reply);
+""")
+
+
+ffi.set_source('_cffi._hiredis',
+"""
+#include <hiredis.h>
+""", include_dirs=[vendored_hiredis], libraries=['hiredis_for_hiredis_py'])
+
+if __name__ == "__main__":
+    ffi.compile()

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,34 @@
 #!/usr/bin/env python
 
 try:
-  from setuptools import setup, Extension
-  from setuptools.command import install_lib as _install_lib
+    from setuptools import setup, Extension
+    from setuptools.command import install_lib as _install_lib
 except ImportError:
-  from distutils.core import setup, Extension
-  from distutils.command import install_lib as _install_lib
-import sys, imp, os, glob
+    from distutils.core import setup, Extension
+    from distutils.command import install_lib as _install_lib
+import glob
+import imp
+import platform
+
 
 def version():
-  module = imp.load_source("hiredis.version", "hiredis/version.py")
-  return module.__version__
+    module = imp.load_source("hiredis.version", "hiredis/version.py")
+    return module.__version__
+
 
 # Patch "install_lib" command to run build_clib before build_ext
 # to properly work with easy_install.
 # See: http://bugs.python.org/issue5243
 class install_lib(_install_lib.install_lib):
-  def build(self):
-    if not self.skip_build:
-      if self.distribution.has_pure_modules():
-        self.run_command('build_py')
-        if self.distribution.has_c_libraries():
-          self.run_command('build_clib')
-        if self.distribution.has_ext_modules():
-          self.run_command('build_ext')
+    def build(self):
+        if not self.skip_build:
+            if self.distribution.has_pure_modules():
+                self.run_command('build_py')
+                if self.distribution.has_c_libraries():
+                    self.run_command('build_clib')
+                if self.distribution.has_ext_modules():
+                    self.run_command('build_ext')
+
 
 # To link the extension with the C library, distutils passes the "-lLIBRARY"
 # option to the linker. This makes it go through its library search path. If it
@@ -40,44 +45,54 @@ class install_lib(_install_lib.install_lib):
 # supported Python versions is worse...
 #
 # Also see: https://github.com/pietern/hiredis-py/issues/15
-lib = ("hiredis_for_hiredis_py", {
-  "sources": ["vendor/hiredis/%s.c" % src for src in ("read", "sds")]})
 
-ext = Extension("hiredis.hiredis",
-  sources=glob.glob("src/*.c"),
-  include_dirs=["vendor"])
+if platform.python_implementation() == "PyPy":
+    setup_extra = {
+        'cffi_modules': ["hiredis/hiredis_build.py:ffi"]
+    }
+else:
+    lib = ("hiredis_for_hiredis_py", {
+        "sources": ["vendor/hiredis/%s.c" % src for src in ("read", "sds")]})
+
+    ext = Extension("hiredis.hiredis",
+                    sources=glob.glob("src/*.c"),
+                    include_dirs=["vendor"])
+
+    setup_extra = {
+        'libraries': [lib],
+        'ext_modules': [ext]
+    }
 
 setup(
-  name="hiredis",
-  version=version(),
-  description="Python wrapper for hiredis",
-  url="https://github.com/redis/hiredis-py",
-  author="Jan-Erik Rediger, Pieter Noordhuis",
-  author_email="janerik@fnordig.de, pcnoordhuis@gmail.com",
-  keywords=["Redis"],
-  license="BSD",
-  packages=["hiredis"],
-  libraries=[lib],
-  ext_modules=[ext],
+    name="hiredis",
+    version=version(),
+    description="Python wrapper for hiredis",
+    url="https://github.com/redis/hiredis-py",
+    author="Jan-Erik Rediger, Pieter Noordhuis",
+    author_email="janerik@fnordig.de, pcnoordhuis@gmail.com",
+    keywords=["Redis"],
+    license="BSD",
+    packages=["hiredis"],
+    # Override "install_lib" command
+    cmdclass={"install_lib": install_lib},
 
-  # Override "install_lib" command
-  cmdclass={ "install_lib": install_lib },
-
-  classifiers=[
-    'Development Status :: 5 - Production/Stable',
-    'Intended Audience :: Developers',
-    'License :: OSI Approved :: BSD License',
-    'Operating System :: MacOS',
-    'Operating System :: POSIX',
-    'Programming Language :: C',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.6',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.2',
-    'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: Implementation :: CPython',
-    'Topic :: Software Development',
-  ],
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: MacOS',
+        'Operating System :: POSIX',
+        'Programming Language :: C',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Topic :: Software Development',
+    ],
+    **setup_extra
 )

--- a/setup.py
+++ b/setup.py
@@ -73,9 +73,6 @@ setup(
     keywords=["Redis"],
     license="BSD",
     packages=["hiredis"],
-    # Override "install_lib" command
-    cmdclass={"install_lib": install_lib},
-
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ else:
 
     setup_extra = {
         'libraries': [lib],
-        'ext_modules': [ext]
+        'ext_modules': [ext],
+        'cmdclass': {"install_lib": install_lib}
     }
 
 setup(

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -4,8 +4,11 @@ version = sys.version.split(" ")[0]
 majorminor = version[0:3]
 
 # Add path to hiredis.so load path
-path = glob.glob("build/lib*-%s/hiredis" % majorminor)[0]
-sys.path.insert(0, path)
+try:
+  path = glob.glob("build/lib*-%s/hiredis" % majorminor)[0]
+  sys.path.insert(0, path)
+except:
+  pass
 
 from unittest import *
 from . import reader


### PR DESCRIPTION
This fixes #41.
It's based on https://github.com/hodgestar/hiredis-cffi and adapted to the current API. Thanks @hodgestar!

What's currently missing:
- [ ] Pass redis-py test suite
- [ ] Benchmark
- [ ] Testing on newer versions of PyPy
- [ ] Test PyPy on Windows?
- [x] Decide if we want to support old versions of PyPy.
  - [x] If we don't I need to convert the old style C -> Python callbacks with the new style callbacks.
