### PR TITLE
Sort list of source files to allow reproducible building

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ lib = ("hiredis_for_hiredis_py", {
   "sources": ["vendor/hiredis/%s.c" % src for src in ("read", "sds")]})
 
 ext = Extension("hiredis.hiredis",
-  sources=glob.glob("src/*.c"),
+  sources=sorted(glob.glob("src/*.c")),
   include_dirs=["vendor"])
 
 setup(


### PR DESCRIPTION
An unsorted list of source files causes the object files to
be linked in the same (non-deterministic) order, which
causes the binaries to differ between builds.