### PR TITLE
Expose len method to retrieve the buffer length

### DIFF
--- a/src/reader.c
+++ b/src/reader.c
@@ -9,12 +9,14 @@ static PyObject *Reader_feed(hiredis_ReaderObject *self, PyObject *args);
 static PyObject *Reader_gets(hiredis_ReaderObject *self);
 static PyObject *Reader_setmaxbuf(hiredis_ReaderObject *self, PyObject *arg);
 static PyObject *Reader_getmaxbuf(hiredis_ReaderObject *self);
+static PyObject *Reader_len(hiredis_ReaderObject *self);
 
 static PyMethodDef hiredis_ReaderMethods[] = {
     {"feed", (PyCFunction)Reader_feed, METH_VARARGS, NULL },
     {"gets", (PyCFunction)Reader_gets, METH_NOARGS, NULL },
     {"setmaxbuf", (PyCFunction)Reader_setmaxbuf, METH_O, NULL },
     {"getmaxbuf", (PyCFunction)Reader_getmaxbuf, METH_NOARGS, NULL },
+    {"len", (PyCFunction)Reader_len, METH_NOARGS, NULL },
     { NULL }  /* Sentinel */
 };
 
@@ -331,4 +333,8 @@ static PyObject *Reader_setmaxbuf(hiredis_ReaderObject *self, PyObject *arg) {
 
 static PyObject *Reader_getmaxbuf(hiredis_ReaderObject *self) {
     return PyLong_FromSize_t(self->reader->maxbuf);
+}
+
+static PyObject *Reader_len(hiredis_ReaderObject *self) {
+    return PyLong_FromSize_t(self->reader->len);
 }

--- a/test/reader.py
+++ b/test/reader.py
@@ -179,3 +179,18 @@ class ReaderTest(TestCase):
     self.reader.setmaxbuf(None)
     self.assertEquals(defaultmaxbuf, self.reader.getmaxbuf())
     self.assertRaises(ValueError, self.reader.setmaxbuf, -4)
+
+  def test_len(self):
+    self.assertEquals(0, self.reader.len())
+    data = b"+ok\r\n"
+    self.reader.feed(data)
+    self.assertEquals(len(data), self.reader.len())
+ 
+    # hiredis reallocates and removes unused buffer once
+    # there is at least 1K of not used data.
+    calls = int((1024 / len(data))) + 1
+    for i in range(calls):
+        self.reader.feed(data)
+        self.reply()
+
+    self.assertEquals(5, self.reader.len())


### PR DESCRIPTION
Len method is gonna be used to apply the proper back pressure in an ad-hoc implementation of the `StreamReader` of _Asyncio_ [1] for _aioredis_. By default in a normal situation, the `StreamReader` provided by _Asyncio_ uses the length of the internal buffer to decide if pause or resume the read from one socket. In the current scenario, using directly the buffer provided by _hiredis_ is necessary publish this method to keep offering that feature to the user.

[1] https://github.com/aio-libs/aioredis/pull/273/files#diff-16f7900982363b78a4e9a528f9dc825cR26