### PR TITLE
Simplify build system

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,49 +2,17 @@
 
 try:
   from setuptools import setup, Extension
-  from setuptools.command import install_lib as _install_lib
 except ImportError:
   from distutils.core import setup, Extension
-  from distutils.command import install_lib as _install_lib
 import sys, imp, os, glob
 
 def version():
   module = imp.load_source("hiredis.version", "hiredis/version.py")
   return module.__version__
 
-# Patch "install_lib" command to run build_clib before build_ext
-# to properly work with easy_install.
-# See: http://bugs.python.org/issue5243
-class install_lib(_install_lib.install_lib):
-  def build(self):
-    if not self.skip_build:
-      if self.distribution.has_pure_modules():
-        self.run_command('build_py')
-        if self.distribution.has_c_libraries():
-          self.run_command('build_clib')
-        if self.distribution.has_ext_modules():
-          self.run_command('build_ext')
-
-# To link the extension with the C library, distutils passes the "-lLIBRARY"
-# option to the linker. This makes it go through its library search path. If it
-# finds a shared object of the specified library in one of the system-wide
-# library paths, it will dynamically link it.
-#
-# We want the linker to statically link the version of hiredis that is included
-# with hiredis-py. However, the linker may pick up the shared library version
-# of hiredis, if it is available through one of the system-wide library paths.
-# To prevent this from happening, we use an obfuscated library name such that
-# the only version the linker will be able to find is the right version.
-#
-# This is a terrible hack, but patching distutils to do the right thing for all
-# supported Python versions is worse...
-#
-# Also see: https://github.com/pietern/hiredis-py/issues/15
-lib = ("hiredis_for_hiredis_py", {
-  "sources": ["vendor/hiredis/%s.c" % src for src in ("read", "sds")]})
-
 ext = Extension("hiredis.hiredis",
-  sources=sorted(glob.glob("src/*.c")),
+  sources=sorted(glob.glob("src/*.c") +
+                 ["vendor/hiredis/%s.c" % src for src in ("read", "sds")]),
   include_dirs=["vendor"])
 
 setup(
@@ -57,11 +25,7 @@ setup(
   keywords=["Redis"],
   license="BSD",
   packages=["hiredis"],
-  libraries=[lib],
   ext_modules=[ext],
-
-  # Override "install_lib" command
-  cmdclass={ "install_lib": install_lib },
 
   python_requires=">=2.6, !=3.0.*, !=3.1.*",
   classifiers=[


### PR DESCRIPTION
A lot of the workarounds in the build file are a result of trying to build the C code as a separate static library from the extension. The same result can be obtained more simply by including these files directly in the extension.