### PR TITLE
Rename `state` to `hiredis_py_module_state`

### DIFF
--- a/src/hiredis.c
+++ b/src/hiredis.c
@@ -28,7 +28,7 @@ static struct PyModuleDef hiredis_ModuleDef = {
     NULL /* m_free */
 };
 #else
-struct hiredis_ModuleState state;
+struct hiredis_ModuleState hiredis_py_module_state;
 #endif
 
 /* Keep pointer around for other classes to access the module state. */

--- a/src/hiredis.h
+++ b/src/hiredis.h
@@ -25,8 +25,8 @@ struct hiredis_ModuleState {
 #if IS_PY3K
 #define GET_STATE(__s) ((struct hiredis_ModuleState*)PyModule_GetState(__s))
 #else
-extern struct hiredis_ModuleState state;
-#define GET_STATE(__s) (&state)
+extern struct hiredis_ModuleState hiredis_py_module_state;
+#define GET_STATE(__s) (&hiredis_py_module_state)
 #endif
 
 /* Keep pointer around for other classes to access the module state. */


### PR DESCRIPTION
Previously, the variable could alias variables named state in other
shared objects, which was causing segfaults when imported after pytorch.
This change makes it less likely that they overlap and cause undefined
behavior.

See also pytorch/pytorch#11471