### PR TITLE
Fix non-utf8 reply parsing causing segmentation fault in Python 3 (in a better way)

### DIFF
--- a/src/reader.c
+++ b/src/reader.c
@@ -105,10 +105,18 @@ static PyObject *createDecodedString(hiredis_ReaderObject *self, const char *str
 }
 
 static void *createError(PyObject *errorCallable, char *errstr, size_t len) {
-    PyObject *obj;
+    PyObject *obj, *errmsg, *args;
 
-    PyObject *args = Py_BuildValue("(s#)", errstr, len);
-    assert(args != NULL); /* TODO: properly handle OOM etc */
+    #if IS_PY3K
+    errmsg = PyUnicode_DecodeUTF8(errstr, len, "replace");
+    #else
+    errmsg = Py_BuildValue("s#", errstr, len);
+    #endif
+    assert(errmsg != NULL); /* TODO: properly handle OOM etc */
+
+    args = PyTuple_Pack(1, errmsg);
+    assert(args != NULL);
+    Py_DECREF(errmsg);
     obj = PyObject_CallObject(errorCallable, args);
     assert(obj != NULL);
     Py_DECREF(args);


### PR DESCRIPTION
[[previous PR]](https://github.com/redis/hiredis-py/pull/67)

It's possible to create Redis error replies that cannot be decoded with 'utf-8' codec in Python3 and cause `UnicodeDecodeError`.

For example:

```
EVAL 'æ' 0
-ERR Error compiling script (new function): user_script:1: unexpected symbol near '�'
```

Last three bytes (excluding whitespaces) are `27 c3 27`. 

```
>>> b'\x27\xc3\x27'.decode('utf-8')

UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc3 in position 1: invalid continuation byte
```

This case is not handled properly and causes segmentation fault. I've added some tests to demonstrate failure: [commit with new tests](https://github.com/un-def/hiredis-py/commit/128ddad5e75cb5a12240d3f4133bea1d68e9c7f2), [failed travis job](https://travis-ci.org/un-def/hiredis-py/builds/433055678).

With this patch any malformed unicode data will be replaced by `U+FFFD` (`REPLACEMENT CHARACTER`). This change affects only Python 3 because in Python 2 raw bytestring (Python 2 `str` type, not `unicode`) is used.
