### PR TITLE
reader: use new redisReader* macros (hiredis 0.14 compat)

### DIFF
--- a/src/reader.c
+++ b/src/reader.c
@@ -171,7 +171,7 @@ redisReplyObjectFunctions hiredis_ObjectFunctions = {
 };
 
 static void Reader_dealloc(hiredis_ReaderObject *self) {
-    redisReplyReaderFree(self->reader);
+    redisReaderFree(self->reader);
     if (self->encoding)
         free(self->encoding);
     Py_XDECREF(self->protocolErrorClass);
@@ -281,7 +281,7 @@ static PyObject *Reader_feed(hiredis_ReaderObject *self, PyObject *args) {
       goto error;
     }
 
-    redisReplyReaderFeed(self->reader, (char *)buf.buf + off, len);
+    redisReaderFeed(self->reader, (char *)buf.buf + off, len);
     PyBuffer_Release(&buf);
     Py_RETURN_NONE;
 
@@ -295,8 +295,8 @@ static PyObject *Reader_gets(hiredis_ReaderObject *self) {
     PyObject *err;
     char *errstr;
 
-    if (redisReplyReaderGetReply(self->reader, (void**)&obj) == REDIS_ERR) {
-        errstr = redisReplyReaderGetError(self->reader);
+    if (redisReaderGetReply(self->reader, (void**)&obj) == REDIS_ERR) {
+        errstr = redisReaderGetError(self->reader);
         /* protocolErrorClass might be a callable. call it, then use it's type */
         err = createError(self->protocolErrorClass, errstr, strlen(errstr));
         if (err != NULL) {


### PR DESCRIPTION
The redisRelyReader* macros have been removed in hiredis 0.14 and replaced by the redisReader* macro family. The new names were introduced in hiredis 0.10.0 in 2011 so we expect the redisReader* macros to be widely available.

Note: This patch made its way to the Debian hiredis-py package; we are using a system-wide version of hiredis as a shared library and not the bundled versions of the individual drivers.