### PR TITLE
Unicode errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,23 @@ To do so, specify the encoding you want to use for decoding replies when
 initializing it:
 
 ```python
->>> reader = hiredis.Reader(encoding="utf-8")
+>>> reader = hiredis.Reader(encoding="utf-8", errors="strict")
 >>> reader.feed("$3\r\n\xe2\x98\x83\r\n")
 >>> reader.gets()
 u'☃'
 ```
 
-When bulk data in a reply could not be properly decoded using the specified
-encoding, it will be returned as a plain string. When the encoding cannot be
-found, a `LookupError` will be raised after calling `gets` for the first reply
-with bulk data (identical to what Python's `unicode` method would do).
+Decoding of bulk data will be attempted using the specified encoding and
+error handler. If the error handler is `'strict'` (the default), a
+`UnicodeDecodeError` is raised when data cannot be dedcoded. This is identical
+to Python's default behavior. Other valid values to `errors` include
+`'replace'`, `'ignore'`, and `'backslashreplace'`. More information on the
+behavior of these error handlers can be found
+[here](https://docs.python.org/3/howto/unicode.html#the-string-type).
+
+
+When the specified encoding cannot be found, a `LookupError` will be raised
+when calling `gets` for the first reply with bulk data.
 
 #### Error handling
 

--- a/src/reader.h
+++ b/src/reader.h
@@ -7,6 +7,7 @@ typedef struct {
     PyObject_HEAD
     redisReader *reader;
     char *encoding;
+    char *errors;
     int shouldDecode;
     PyObject *protocolErrorClass;
     PyObject *replyErrorClass;


### PR DESCRIPTION
Add an `errors` argument to Reader objects to be used in conjunction with the `encoding` argument. Valid values for `errors` are `'strict'` (the default), `'replace'`, `'ignore'`, or `'backslashreplace'`. These four values are defined by Python: https://docs.python.org/3/howto/unicode.html#the-string-type 

Note this is a backwards incompatible change. Prior to this change hiredis-py would silence `UnicodeDecodeError`s and return the original `bytes` object. After this change, the default behavior is to raise the `UnicodeDecodeError` when a decoding error is encountered. This matches Python's default behavior. The user can alter the default behavior by specifying a different value to `errors` just like normal Python.

Fixes redis/hiredis-py#81