### PR TITLE
Update pypi.python.org URL to pypi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ It primarily speeds up parsing of multi bulk replies.
 
 ## Install
 
-hiredis-py is available on [PyPi](http://pypi.python.org/pypi/hiredis), and
-can be installed with:
+hiredis-py is available on [PyPI](https://pypi.org/project/hiredis/), and can
+be installed with:
 
 ```
 pip install hiredis


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html

Also Correct capitalization of PyPI as spelled on https://pypi.org/.