### PR TITLE
Allow "encoding" and "errors" attributes to be updated at runtime

### DIFF
--- a/src/reader.c
+++ b/src/reader.c
@@ -387,6 +387,6 @@ static PyObject *Reader_set_encoding(hiredis_ReaderObject *self, PyObject *args,
     if(_Reader_set_encoding(self, encoding, errors) == -1)
         return NULL;
 
-    return Py_None;
+    Py_RETURN_NONE;
 
 }


### PR DESCRIPTION
This patch provides three changes:

1. Adds the `Reader.set_encoding` method. This method accepts the "encoding"
and "errors" arguments, verifies that both are either NULL or found within
the codecs module and then updates the Reader's state to use the new values.

    The motivation here is to allow a user to update the Reader's encoding
functionality at runtime, perhaps temporarily. redis-py plans to use this to provide
context manager support. Something like:

    ```python
    client = redis.Redis(encoding="utf-8")
    # gets the value of the "my-utf8-key" decoded as "utf-8" and returns a unicode string
    client.get("my-utf8-key")

    with client.response_context(encoding=None) as no_decode_client:
        # gets the value of "my-bytes-key" and returns it as a bytes object
        no_decode_client.get("my-bytes-key")
    ```

    In the above example, the context manager will call `Reader.set_encoding`,
passing the `encoding=None` argument to update the Reader state. When the
context manager exits, it will again call `Reader.set_encoding` to restore the original "encoding" and "errors" values.

2. Allows both `Reader.__init__` and `Reader.set_encoding` to accept Python None
values for "encoding" and "errors". When `encoding=None` is specified,
hiredis-py will not decode strings and instead return bytes objects.

3. Passing an invalid "encoding" to `Reader.__init__` or `Reader.set_encoding`
will immediately raise a `LookupError`. Prior to this, `Reader.__init__` would
accept an invalid encoding and then raise the `LookupError` the first time
the Reader attempted to decode a string. Raising the error immediately
seems preferable.