### PR TITLE
setup.py: fix build with gcc 4.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ def version():
 ext = Extension("hiredis.hiredis",
   sources=sorted(glob.glob("src/*.c") +
                  ["vendor/hiredis/%s.c" % src for src in ("alloc", "read", "sds")]),
+  extra_compile_args=["-std=c99"],
   include_dirs=["vendor"])
 
 setup(


### PR DESCRIPTION
Fix the following build failure on gcc 4.8 which is raised since version 2.0.0 and https://github.com/redis/hiredis-py/commit/9084152f624e8e593b4e86ddf8bd13329fdfc043:

```
vendor/hiredis/read.c: In function 'redisReaderFree':
vendor/hiredis/read.c:646:9: error: 'for' loop initial declarations are only allowed in C99 mode
         for (int i = 0; i < r->tasks; i++) {
         ^
vendor/hiredis/read.c:646:9: note: use option -std=c99 or -std=gnu99 to compile your code
```

This build failure is raised because hiredis source code is built without C99: https://github.com/redis/hiredis/commit/13a35bdb64615e381c5e1151cdd4e78bba71a6db

Fixes:
 - http://autobuild.buildroot.org/results/04cbcddf6d83ebad8c98400754f9445375e9e489

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>