### PR TITLE
setup.py: add "-std=c99" compiler flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ def version():
 ext = Extension("hiredis.hiredis",
   sources=sorted(glob.glob("src/*.c") +
                  ["vendor/hiredis/%s.c" % src for src in ("alloc", "read", "sds")]),
-  include_dirs=["vendor"])
+  include_dirs=["vendor"],
+  extra_compile_args=["-std=c99"])
 
 setup(
   name="hiredis",


### PR DESCRIPTION
Some (old) compilers can't compile hiredis because of the following error:

```
vendor/hiredis/read.c:646:9: error: 'for' loop initial declarations are only allowed in C99 mode
         for (int i = 0; i < r->tasks; i++) {
         ^
vendor/hiredis/read.c:646:9: note: use option -std=c99 or -std=gnu99 to compile your code
```

The addition of this flag fixes the issue.

Signed-off-by: Asaf Kahlon <asafka7@gmail.com>