### PR TITLE
Allow to specify value returned by `gets` when not enough data is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ Example:
 b'hello'
 ```
 
-When the buffer does not contain a full reply, `gets` returns `False`. This
-means extra data is needed and `feed` should be called again before calling
-`gets` again:
+When the buffer does not contain a full reply, `gets` returns `False`.
+This means extra data is needed and `feed` should be called again before calling
+`gets` again. Alternatively you could provide custom sentinel object via parameter,
+which is useful for RESP3 protocol where native boolean types are supported:
+
+Example:
 
 ```python
 >>> reader.feed("*2\r\n$5\r\nhello\r\n")
@@ -58,6 +61,9 @@ False
 >>> reader.feed("$5\r\nworld\r\n")
 >>> reader.gets()
 [b'hello', b'world']
+>>> reader = hiredis.Reader(notEnoughData=Ellipsis)
+>>> reader.gets()
+Ellipsis
 ```
 
 #### Unicode

--- a/hiredis/hiredis.pyi
+++ b/hiredis/hiredis.pyi
@@ -11,6 +11,7 @@ class Reader:
         replyError: Callable[[str], Exception] = ...,
         encoding: Optional[str] = ...,
         errors: Optional[str] = ...,
+        notEnoughData: Any = ...,
     ) -> None: ...
     def feed(
         self, __buf: Union[str, bytes], __off: int = ..., __len: int = ...

--- a/src/reader.h
+++ b/src/reader.h
@@ -11,6 +11,7 @@ typedef struct {
     int shouldDecode;
     PyObject *protocolErrorClass;
     PyObject *replyErrorClass;
+    PyObject *notEnoughDataObject;
 
     /* Stores error object in between incomplete calls to #gets, in order to
      * only set the error once a full reply has been read. Otherwise, the

--- a/test/reader.py
+++ b/test/reader.py
@@ -314,3 +314,7 @@ class ReaderTest(TestCase):
     self.assertEquals(True, self.reader.has_data())
     self.reply()
     self.assertEquals(False, self.reader.has_data())
+
+  def test_custom_not_enough_data(self):
+    self.reader = hiredis.Reader(notEnoughData=Ellipsis)
+    assert self.reader.gets() is Ellipsis


### PR DESCRIPTION
As RESP3 has been introduced it has native boolean types, to be able to
differentiate between insufficient data in buffer and actual False value
add option to specify custom sentinel.

CamelCase is used to conform to other arguments naming.

Closes: #114