### PR TITLE
chore: update hiredis submodule rev and protocol, github no longer supports anon git protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/hiredis"]
 	path = vendor/hiredis
-	url = git://github.com/redis/hiredis.git
+	url = https://github.com/redis/hiredis.git


### PR DESCRIPTION
re submodule protocol error

```
❯ git submodule update --init --recursive                                                                                                                     
Cloning into '/home/kapilt/projects/hiredis-py/vendor/hiredis'...                                                                                             
fatal: remote error:                                                                                                                                          
  The unauthenticated git protocol on port 9418 is no longer supported.                                                                                       
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.                                                       
fatal: clone of 'git://github.com/redis/hiredis.git' into submodule path '/home/kapilt/projects/hiredis-py/vendor/hiredis' failed                             
Failed to clone 'vendor/hiredis'. Retry scheduled                                                                                                             
Cloning into '/home/kapilt/projects/hiredis-py/vendor/hiredis'...              
fatal: remote error:                                                                                                                                          
  The unauthenticated git protocol on port 9418 is no longer supported.                                                                                       
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.                                                       
fatal: clone of 'git://github.com/redis/hiredis.git' into submodule path '/home/kapilt/projects/hiredis-py/vendor/hiredis' failed                             
Failed to clone 'vendor/hiredis' a second time, aborting   
```

re version bump, hiredis 1.0.0 has an extant cve, https://github.com/redis/hiredis/security/advisories/GHSA-hfm9-39pp-55p2
