### PR TITLE
.travis.yml: make use of CFLAG=-std=c99

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,13 @@ matrix:
   - sudo: required
     services:
       - docker
-    env: HIREDIS_PY_BUILDWHEELS=1
+    env: HIREDIS_PY_BUILDWHEELS=1 CFLAGS="-std=c99"
   # linux aarch64 (arm64) wheels
   - arch: arm64
     sudo: required
     services:
       - docker
-    env: HIREDIS_PY_BUILDWHEELS=1
+    env: HIREDIS_PY_BUILDWHEELS=1 CFLAGS="-std=c99"
   # osx wheels
   - os: osx
     osx_image: xcode9.4


### PR DESCRIPTION
make use of CFLAG=-std=c99 for travis CI build
It can support building hiredis-py for old gcc versions (manylinux1, centos7 with gcc 4.8.5) etc.

related issue https://github.com/redis/hiredis-py/issues/121