### PR TITLE
Python 3.11 trove, and links back to the project

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@ setup(
   package_data={"hiredis": ["hiredis.pyi", "py.typed"]},
   ext_modules=[ext],
   python_requires=">=3.6",
+  project_urls={
+        "Changes": "https://github.com/redis/hiredis-py/releases",
+        "Issue tracker": "https://github.com/hiredis/redis-py/issues",
+  }
   classifiers=[
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
@@ -45,6 +49,7 @@ setup(
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Software Development',
   ],

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
   project_urls={
         "Changes": "https://github.com/redis/hiredis-py/releases",
         "Issue tracker": "https://github.com/hiredis/redis-py/issues",
-  }
+  },
   classifiers=[
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',
@@ -44,6 +44,7 @@ setup(
     'Operating System :: POSIX',
     'Programming Language :: C',
     'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
This pull request updates the troves for PyPi. Firstly, we're adding a trove for the newly released 3.11. Additionally, links back to the project are part of this PR.

Finally, a the Python 3 :: Only trove was added, for those searching for libraries supporting only Python3.