### PR TITLE
Supporting hiredis 1.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/hiredis"]
 	path = vendor/hiredis
-	url = git://github.com/redis/hiredis.git
+	url = https://github.com/redis/hiredis


### PR DESCRIPTION
In addition to bumping the vendored hiredis, I updated the location to point to the https origin. This eliminates the issue for not github/ssh users.

Closes #134 