### PR TITLE
Use absolute imports and remove __init__.py from tests.

### DIFF
--- a/.github/workflows/freebsd.yaml
+++ b/.github/workflows/freebsd.yaml
@@ -43,5 +43,5 @@ jobs:
              /usr/local/bin/pip install -U pip setuptools wheel
              /usr/local/bin/pip install -r dev_requirements.txt
              /usr/local/bin/python3.9 setup.py build_ext --inplace
-             pytest
+             python -m pytest
              python3.9 setup.py bdist_wheel

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -45,7 +45,7 @@ jobs:
            pip install -U pip setuptools wheel
            pip install -r dev_requirements.txt
            python setup.py build_ext --inplace
-           pytest
+           python -m pytest
        - name: build and install the wheel
          run: |
            python setup.py bdist_wheel

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Building this repository requires a recursive checkout of submodules, and buildi
 ```bash
 git clone --recursse-submodules https://github.com/redis/hiredis-py
 python setup.py build_ext --inplace
-pytest
+python -m pytest
 ```
 
 ### Requirements

--- a/hiredis/__init__.py
+++ b/hiredis/__init__.py
@@ -1,5 +1,5 @@
-from .hiredis import Reader, HiredisError, pack_command, ProtocolError, ReplyError
-from .version import __version__
+from hiredis.hiredis import Reader, HiredisError, pack_command, ProtocolError, ReplyError
+from hiredis.version import __version__
 
 __all__ = [
   "Reader",


### PR DESCRIPTION
This makes it possible to run the test suite against an installed hiredis-py.