### PR TITLE
Badge for latest released on Pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/redis/hiredis-py/actions/workflows/integration.yaml/badge.svg)](https://github.com/redis/hiredis-py/actions/workflows/integration.yaml)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![pypi](https://badge.fury.io/py/hiredis.svg)](https://pypi.org/project/hiredis/)
 
 Python extension that wraps protocol parsing code in [hiredis][hiredis].
 It primarily speeds up parsing of multi bulk replies.


### PR DESCRIPTION
Exposing the latest release to pypy as a badge, in case it differs. The result of #171.

closes #171