### PR TITLE
Update Python 3.13 compatibility

### DIFF
--- a/.github/workflows/REUSABLE-wheeler.yaml
+++ b/.github/workflows/REUSABLE-wheeler.yaml
@@ -37,7 +37,7 @@ jobs:
            platforms: all
 
        - name: Build wheels
-         uses: pypa/cibuildwheel@v2.19.2
+         uses: pypa/cibuildwheel@v2.21.3
          env:
            # configure cibuildwheel to build native archs ('auto'), and some
            # emulated ones

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,7 @@ jobs:
      strategy:
        max-parallel: 15
        matrix:
-         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.8', 'pypy-3.9']
+         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
          os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
        fail-fast: false
      env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 * Implement pack_command that serializes redis-py command to the RESP bytes object.
 * Implement garbage collection support in Reader (#162)
 * Python 3.12
+* Python 3.13 compatibility
 
 ### 2.1.1 (2023-10-01)
 

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Software Development',
     ],


### PR DESCRIPTION
Fixes #186

Updates CI to build cp313 wheels. Adds pypy-3.10 testing as well.

See also https://github.com/redis/hiredis-py/pull/174.

@chayim could you take a look? 


