### PR TITLE
Fix reply map value memory leak

### DIFF
--- a/src/reader.c
+++ b/src/reader.c
@@ -80,6 +80,7 @@ static void *tryParentize(const redisReadTask *task, PyObject *obj) {
                     PyObject *last_item = PyObject_CallMethod(parent, "popitem", NULL);
                     PyObject *last_key = PyTuple_GetItem(last_item, 0);
                     PyDict_SetItem(parent, last_key, obj);
+                    Py_DECREF(obj);
                 }
                 break;
             default:


### PR DESCRIPTION
https://github.com/redis/hiredis-py/issues/175

PyDict_SetItem doesn't steal a reference to the value, so a Py_DECREF is required. Adding one seems to have solved the memory leak for me.