### PR TITLE
Introduce new type for RESP3 PUSH notifications

### DIFF
--- a/hiredis/__init__.py
+++ b/hiredis/__init__.py
@@ -1,4 +1,4 @@
-from hiredis.hiredis import Reader, HiredisError, pack_command, ProtocolError, ReplyError
+from hiredis.hiredis import Reader, HiredisError, pack_command, ProtocolError, ReplyError, PushNotification
 from hiredis.version import __version__
 
 __all__ = [
@@ -6,5 +6,6 @@ __all__ = [
   "HiredisError",
   "pack_command",
   "ProtocolError",
+  "PushNotification",
   "ReplyError",
   "__version__"]

--- a/hiredis/hiredis.pyi
+++ b/hiredis/hiredis.pyi
@@ -13,6 +13,10 @@ class ReplyError(HiredisError):
     ...
 
 
+class PushNotification(list):
+    ...
+
+
 class Reader:
     def __init__(
         self,

--- a/src/hiredis.c
+++ b/src/hiredis.c
@@ -59,6 +59,11 @@ PyMODINIT_FUNC PyInit_hiredis(void)
         return NULL;
     }
 
+    PushNotificationType.tp_base = &PyList_Type;
+    if (PyType_Ready(&PushNotificationType) < 0) {
+        return NULL;
+    }
+
     mod_hiredis = PyModule_Create(&hiredis_ModuleDef);
 
     /* Setup custom exceptions */
@@ -78,6 +83,9 @@ PyMODINIT_FUNC PyInit_hiredis(void)
 
     Py_INCREF(&hiredis_ReaderType);
     PyModule_AddObject(mod_hiredis, "Reader", (PyObject *)&hiredis_ReaderType);
+
+    Py_INCREF(&PushNotificationType);
+    PyModule_AddObject(mod_hiredis, "PushNotification", (PyObject *)&PushNotificationType);
 
     return mod_hiredis;
 }

--- a/src/reader.c
+++ b/src/reader.c
@@ -221,7 +221,6 @@ static int PushNotificationType_init(PushNotificationObject *self, PyObject *arg
     return PyList_Type.tp_init((PyObject *)self, args, kwds);
 }
 
-/* Create a new instance of PushNotificationType with preallocated number of elements */
 static PyObject* PushNotificationType_New(Py_ssize_t size) {
     /* Check for negative size */
     if (size < 0) {
@@ -240,28 +239,8 @@ static PyObject* PushNotificationType_New(Py_ssize_t size) {
         return NULL;
     }
 
-    /* Cast to PyListObject to access its fields */
-    PyListObject* op = (PyListObject*)obj;
-
-    /* Allocate memory for the list items if size > 0 */
-    if (size > 0) {
-        size_t nbytes = (size_t)size * sizeof(PyObject*);
-        op->ob_item = (PyObject**)PyMem_Malloc(nbytes);
-        if (op->ob_item == NULL) {
-            Py_DECREF(obj);
-            return PyErr_NoMemory();
-        }
-        /* Initialize memory to zeros */
-        memset(op->ob_item, 0, nbytes);
-    }
-
-    /* Set the size and allocated fields */
-#if PY_VERSION_HEX >= 0x03090000
-    Py_SET_SIZE(op, size);
-#else
-    Py_SIZE(op) = size;
-#endif
-    op->allocated = size;
+    // Simple solution to preallocate the list that works for both CPython and PyPy
+    PyList_SetSlice(obj, PY_SSIZE_T_MAX, PY_SSIZE_T_MAX, PyList_New(size));
 
     return obj;
 }

--- a/src/reader.c
+++ b/src/reader.c
@@ -1,6 +1,7 @@
 #include "reader.h"
 
 #include <assert.h>
+#include <Python.h>
 
 static void Reader_dealloc(hiredis_ReaderObject *self);
 static int Reader_traverse(hiredis_ReaderObject *self, visitproc visit, void *arg);
@@ -13,6 +14,10 @@ static PyObject *Reader_getmaxbuf(hiredis_ReaderObject *self);
 static PyObject *Reader_len(hiredis_ReaderObject *self);
 static PyObject *Reader_has_data(hiredis_ReaderObject *self);
 static PyObject *Reader_set_encoding(hiredis_ReaderObject *self, PyObject *args, PyObject *kwds);
+
+static int PushNotificationType_init(PushNotificationObject *self, PyObject *args, PyObject *kwds);
+/* Create a new instance of PushNotificationType with preallocated number of elements */
+static PyObject* PushNotificationType_New(Py_ssize_t size);
 
 static PyMethodDef hiredis_ReaderMethods[] = {
     {"feed", (PyCFunction)Reader_feed, METH_VARARGS, NULL },
@@ -64,6 +69,16 @@ PyTypeObject hiredis_ReaderType = {
     (initproc)Reader_init,        /*tp_init */
     0,                            /*tp_alloc */
     Reader_new,                   /*tp_new */
+};
+
+PyTypeObject PushNotificationType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = MOD_HIREDIS ".PushNotification",
+    .tp_basicsize = sizeof(PushNotificationObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_doc = "Redis PUSH notification type",
+    .tp_init = (initproc) PushNotificationType_init,
 };
 
 static void *tryParentize(const redisReadTask *task, PyObject *obj) {
@@ -165,6 +180,9 @@ static void *createArrayObject(const redisReadTask *task, size_t elements) {
         case REDIS_REPLY_MAP:
             obj = PyDict_New();
             break;
+        case REDIS_REPLY_PUSH:
+            obj = PushNotificationType_New(elements);
+            break;
         default:
             obj = PyList_New(elements);
     }
@@ -197,6 +215,55 @@ static void *createBoolObject(const redisReadTask *task, int bval) {
 
 static void freeObject(void *obj) {
     Py_XDECREF(obj);
+}
+
+static int PushNotificationType_init(PushNotificationObject *self, PyObject *args, PyObject *kwds) {
+    return PyList_Type.tp_init((PyObject *)self, args, kwds);
+}
+
+/* Create a new instance of PushNotificationType with preallocated number of elements */
+static PyObject* PushNotificationType_New(Py_ssize_t size) {
+    /* Check for negative size */
+    if (size < 0) {
+        PyErr_SetString(PyExc_SystemError, "negative list size");
+        return NULL;
+    }
+
+    /* Check for potential overflow */
+    if ((size_t)size > PY_SSIZE_T_MAX / sizeof(PyObject*)) {
+        return PyErr_NoMemory();
+    }
+
+    /* Create a new instance of PushNotificationType */
+    PyObject* obj = PyType_GenericNew(&PushNotificationType, NULL, NULL);
+    if (obj == NULL) {
+        return NULL;
+    }
+
+    /* Cast to PyListObject to access its fields */
+    PyListObject* op = (PyListObject*)obj;
+
+    /* Allocate memory for the list items if size > 0 */
+    if (size > 0) {
+        size_t nbytes = (size_t)size * sizeof(PyObject*);
+        op->ob_item = (PyObject**)PyMem_Malloc(nbytes);
+        if (op->ob_item == NULL) {
+            Py_DECREF(obj);
+            return PyErr_NoMemory();
+        }
+        /* Initialize memory to zeros */
+        memset(op->ob_item, 0, nbytes);
+    }
+
+    /* Set the size and allocated fields */
+#if PY_VERSION_HEX >= 0x03090000
+    Py_SET_SIZE(op, size);
+#else
+    Py_SIZE(op) = size;
+#endif
+    op->allocated = size;
+
+    return obj;
 }
 
 redisReplyObjectFunctions hiredis_ObjectFunctions = {

--- a/src/reader.c
+++ b/src/reader.c
@@ -233,14 +233,21 @@ static PyObject* PushNotificationType_New(Py_ssize_t size) {
         return PyErr_NoMemory();
     }
 
-    /* Create a new instance of PushNotificationType */
+#ifdef PYPY_VERSION
+    PyObject* obj = PyObject_CallObject((PyObject *) &PushNotificationType, NULL);    
+#else
     PyObject* obj = PyType_GenericNew(&PushNotificationType, NULL, NULL);
+#endif
     if (obj == NULL) {
         return NULL;
     }
 
-    // Simple solution to preallocate the list that works for both CPython and PyPy
-    PyList_SetSlice(obj, PY_SSIZE_T_MAX, PY_SSIZE_T_MAX, PyList_New(size));
+   int res = PyList_SetSlice(obj, PY_SSIZE_T_MAX, PY_SSIZE_T_MAX, PyList_New(size));
+
+   if (res == -1) {
+       Py_DECREF(obj);
+       return NULL;
+   }
 
     return obj;
 }

--- a/src/reader.h
+++ b/src/reader.h
@@ -23,7 +23,12 @@ typedef struct {
     } error;
 } hiredis_ReaderObject;
 
+typedef struct {
+    PyListObject list;
+} PushNotificationObject;
+
 extern PyTypeObject hiredis_ReaderType;
+extern PyTypeObject PushNotificationType;
 extern redisReplyObjectFunctions hiredis_ObjectFunctions;
 
 #endif

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -185,9 +185,11 @@ def test_dict_with_unhashable_key(reader):
     with pytest.raises(TypeError):
       reader.gets()
 
-def test_vector(reader):
+def test_vector(reader):  
   reader.feed(b">4\r\n+pubsub\r\n+message\r\n+channel\r\n+message\r\n")
-  assert [b"pubsub", b"message", b"channel", b"message"] == reader.gets()
+  result = reader.gets()
+  assert isinstance(result, hiredis.PushNotification)
+  assert [b"pubsub", b"message", b"channel", b"message"] == result
 
 def test_verbatim_string(reader):
   value = b"text"


### PR DESCRIPTION
Allow clients to distinguish between RESP3 arrays and PUSH types by introducing PushNotification type, which subclasses list.

Fix #128