### PR TITLE
Add Python 3.14 to CI and wheels

### DIFF
--- a/.github/workflows/REUSABLE-wheeler.yaml
+++ b/.github/workflows/REUSABLE-wheeler.yaml
@@ -37,7 +37,7 @@ jobs:
            platforms: all
 
        - name: Build wheels
-         uses: pypa/cibuildwheel@v2.21.3
+         uses: pypa/cibuildwheel@v3.2.0
          env:
            # configure cibuildwheel to build native archs ('auto'), and some
            # emulated ones

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,7 @@ jobs:
      strategy:
        max-parallel: 15
        matrix:
-         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
+         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
          os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
        fail-fast: false
      env:

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Software Development',
     ],


### PR DESCRIPTION
`redis[hiredis]` fails to install on Python 3.14 due to missing wheels on some setups. Similar to what was done for 3.13 in #199 I:

- Added 3.14 to the CI matrix
- Bumped pypa/cibuildwheel to v3.2.0
- added 3.14 to `setup.py`

I hope this is all that's needed for 3.14 support but I guess we won't know until CI ran.

Another suggestion a maintainer might want to look into is adding a `dependabot.yaml` so that you get update notifications for the [pypa/cibuildwheel ](https://github.com/pypa/cibuildwheel) action. This way you would have gotten automatic 3.14 wheel builds 'for free' since [July](https://github.com/pypa/cibuildwheel/releases/tag/v3.1.0), but I guess that's a nuanced decision at what point and how to introduce testing of new Python releases to CI. Updating the action would not have added 3.14 to the test matrix.

Cheers!