### PR TITLE
Test against 3.13t and 3.14t

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,7 @@ jobs:
      strategy:
        max-parallel: 15
        matrix:
-         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.15.0-alpha.7', 'pypy-3.9', 'pypy-3.10', 'pypy-3.11']
+         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.13t', '3.14', '3.14t', '3.15.0-alpha.7', 'pypy-3.9', 'pypy-3.10', 'pypy-3.11']
          os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
        fail-fast: false
      env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that expands the GitHub Actions test matrix; the main risk is longer runtimes or new failures on the added Python variants.
> 
> **Overview**
> Updates the GitHub Actions integration workflow to also run the test suite on the `3.13t` and `3.14t` Python builds by extending the `python-version` matrix in `.github/workflows/integration.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e76ee59b476959f8f5ad3fe9dd0c859c072cb6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->