### PR TITLE
MNT: do not use deprecated load_module method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,14 @@ try:
     from setuptools import setup, Extension
 except ImportError:
     from distutils.core import setup, Extension
-import importlib
+import runpy
 import glob
 import io
 import sys
 
 
 def version():
-    loader = importlib.machinery.SourceFileLoader(
-        "hiredis.version", "hiredis/version.py")
-    module = loader.load_module()
-    return module.__version__
+    return runpy.run_path("hiredis/version.py")["__version__"]
 
 
 def get_sources():


### PR DESCRIPTION
The load_module method has been deprecated from py34 and will be removed in py315 [1] (it is already gone on CPython main).

The recommended replacement is exec_module, however the documentation [2] suggests to use a simpler approach than using the loaders directly and runpy [3] seemed better than sys.path hacking.

Given that this is a one-line file simply reading the file and parsing it 'by hand' is an option.

[1] https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module
[2] https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
[3] https://docs.python.org/3/library/runpy.html#runpy.run_path