### PR TITLE
Add Python 3.15.0a7 to CI matrix

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,7 @@ jobs:
      strategy:
        max-parallel: 15
        matrix:
-         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
+         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.15.0a7', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
          os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
        fail-fast: false
      env:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,7 @@ jobs:
      strategy:
        max-parallel: 15
        matrix:
-         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.15.0a7', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
+         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.15.0-alpha.7', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
          os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
        fail-fast: false
      env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to CI configuration; main impact is potentially increased flakiness or longer runtimes due to adding an alpha Python version.
> 
> **Overview**
> Expands the GitHub Actions integration test matrix to include `3.15.0-alpha.7`, so the full test/build workflow runs against the upcoming Python release in addition to the existing CPython and PyPy versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22800b1b0a54cd23925ad13f42484dd16b004dbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->