### PR TITLE
Bump GitHub action versions

### DIFF
--- a/.github/workflows/REUSABLE-wheeler.yaml
+++ b/.github/workflows/REUSABLE-wheeler.yaml
@@ -26,7 +26,7 @@ jobs:
        CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
        MACOSX_DEPLOYMENT_TARGET: "10.15"
      steps:
-       - uses: actions/checkout@v4
+       - uses: actions/checkout@v6
          with:
            submodules: recursive
 
@@ -55,7 +55,7 @@ jobs:
        - uses: actions/setup-python@v5
          with:
            python-version: '3.10'
-       - uses: actions/checkout@v4
+       - uses: actions/checkout@v6
          with:
            submodules: recursive
        - name: Build sdist

--- a/.github/workflows/freebsd.yaml
+++ b/.github/workflows/freebsd.yaml
@@ -26,7 +26,7 @@ jobs:
        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
      name: Python ${{ matrix.python-version }} FreeBSD
      steps:
-       - uses: actions/checkout@v4
+       - uses: actions/checkout@v6
          with:
            submodules: recursive
        - name: build and test

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -32,7 +32,7 @@ jobs:
        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
      name: Python ${{ matrix.python-version }} ${{matrix.os}}
      steps:
-       - uses: actions/checkout@v3
+       - uses: actions/checkout@v6
          with:
            submodules: recursive
        - uses: actions/setup-python@v6

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -35,7 +35,7 @@ jobs:
        - uses: actions/checkout@v3
          with:
            submodules: recursive
-       - uses: actions/setup-python@v4
+       - uses: actions/setup-python@v6
          with:
            python-version: ${{ matrix.python-version }}
            cache: 'pip'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates GitHub Action versions used in CI/release workflows, with no product code changes. Main risk is CI behavior changing due to new action major versions.
> 
> **Overview**
> Updates CI/release workflows to newer major versions of GitHub Actions.
> 
> `actions/checkout` is bumped to `v6` across wheel-building, FreeBSD, and integration workflows, and the integration workflow also bumps `actions/setup-python` to `v6` (keeping existing job logic intact).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76ce1d7126e0d179bd6af974b6ad2a08ca5105a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->