### PR TITLE
Drop python and pypy 3.8 support, test against pypy-3.11

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,7 @@ jobs:
      strategy:
        max-parallel: 15
        matrix:
-         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.15.0-alpha.7', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
+         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.15.0-alpha.7', 'pypy-3.9', 'pypy-3.10', 'pypy-3.11']
          os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
        fail-fast: false
      env:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ python -m pytest
 
 ### Requirements
 
-hiredis-py requires **Python 3.8+**.
+hiredis-py requires **Python 3.9+**.
 
 Make sure Python development headers are available when installing hiredis-py.
 On Ubuntu/Debian systems, install them with `apt-get install python3-dev`.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk since this only changes supported/tested runtime versions (no code changes), but it may break users still on CPython/PyPy 3.8.
> 
> **Overview**
> Drops Python 3.8 from the project’s stated requirements and CI coverage by updating `README.md` to require **Python 3.9+** and removing `3.8`/`pypy-3.8` from the GitHub Actions test matrix.
> 
> Expands CI coverage for PyPy by adding `pypy-3.11` to the integration workflow matrix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae737591e7cdda2a6b521e5317a7965ddaa0ae41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->