### PR TITLE
Add support for building and releasing hiredis-py on Windows ARM64

### DIFF
--- a/.github/workflows/REUSABLE-wheeler.yaml
+++ b/.github/workflows/REUSABLE-wheeler.yaml
@@ -21,7 +21,7 @@ jobs:
      runs-on: ${{ matrix.os }}
      strategy:
        matrix:
-         os: [ubuntu-latest, windows-latest, macos-latest]
+         os: [ubuntu-latest, windows-latest, windows-11-arm, macos-latest]
      env:
        CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
        MACOSX_DEPLOYMENT_TARGET: "10.15"
@@ -37,11 +37,18 @@ jobs:
            platforms: all
 
        - name: Build wheels
+         if: matrix.os != 'windows-11-arm'
          uses: pypa/cibuildwheel@v3.2.0
          env:
            # configure cibuildwheel to build native archs ('auto'), and some
            # emulated ones
            CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
+
+       - name: Build wheels on Windows ARM64
+         if: matrix.os == 'windows-11-arm'
+         uses: pypa/cibuildwheel@v3.2.0
+         env:
+           CIBW_ARCHS_WINDOWS: ARM64
 
        - uses: actions/upload-artifact@v4
          with:
@@ -88,6 +95,10 @@ jobs:
            path: artifacts/windows
        - uses: actions/download-artifact@v4
          with:
+           name: windows-11-arm-wheels
+           path: artifacts/windows-arm64
+       - uses: actions/download-artifact@v4
+         with:
            name: macos-latest-wheels
            path: artifacts/macos
        - uses: actions/download-artifact@v4
@@ -98,6 +109,7 @@ jobs:
          run: |
           mkdir dist
           cp -R artifacts/windows/* dist
+          cp -R artifacts/windows-arm64/* dist
           cp -R artifacts/linux/* dist
           cp -R artifacts/macos/* dist
           cp -R artifacts/sdist/* dist


### PR DESCRIPTION
**PR Description:**

- The PR adds support for building and releasing Hiredis-py wheels on Windows ARM64

**Changes Proposed:**

- Added Windows ARM64 build configuration in the wheel builder workflow file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; main risk is missing/incorrect Windows ARM64 artifacts causing failed releases or incomplete wheel uploads.
> 
> **Overview**
> Adds Windows ARM64 wheel builds to the reusable wheel-builder GitHub Actions workflow.
> 
> The wheel matrix now includes `windows-11-arm`, runs a dedicated `cibuildwheel` step with `CIBW_ARCHS_WINDOWS: ARM64`, and updates the publish job to download and merge the new ARM64 wheel artifacts into `dist` before publishing to PyPI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ba3a688e7468bb948a2b04274c44256ebab4074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->