### PR TITLE
Run integration tests on Windows ARM64 for Python 3.11 and 3.14

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -27,6 +27,11 @@ jobs:
        matrix:
          python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.15.0-alpha.7', 'pypy-3.9', 'pypy-3.10', 'pypy-3.11']
          os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+         include:
+           - os: 'windows-11-arm'
+             python-version: '3.11'
+           - os: 'windows-11-arm'
+             python-version: '3.14'
        fail-fast: false
      env:
        ACTIONS_ALLOW_UNSECURE_COMMANDS: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change; main impact is longer/flake-prone builds due to adding a new runner architecture to the test matrix.
> 
> **Overview**
> Extends the GitHub Actions integration test matrix to also run on **Windows ARM64** (`windows-11-arm`) for Python **3.11** and **3.14** via `matrix.include` in `integration.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2165bdb980fc1022d182c0ce4ae0a23cbd07f8d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->