### PR TITLE
Update workflow versions to address Node v20 deprecation

### DIFF
--- a/.github/workflows/REUSABLE-wheeler.yaml
+++ b/.github/workflows/REUSABLE-wheeler.yaml
@@ -50,7 +50,7 @@ jobs:
          env:
            CIBW_ARCHS_WINDOWS: ARM64
 
-       - uses: actions/upload-artifact@v5
+       - uses: actions/upload-artifact@v6
          with:
            name: ${{matrix.os}}-wheels
            path: ./wheelhouse/*.whl
@@ -68,7 +68,7 @@ jobs:
        - name: Build sdist
          run: |
            python3 setup.py sdist
-       - uses: actions/upload-artifact@v5
+       - uses: actions/upload-artifact@v6
          with:
            name: source-dist
            path: ./dist/*.tar.gz
@@ -85,23 +85,23 @@ jobs:
        - name: Install tools
          run: |
            pip install twine wheel
-       - uses: actions/download-artifact@v5
+       - uses: actions/download-artifact@v6
          with:
            name: ubuntu-latest-wheels
            path: artifacts/linux
-       - uses: actions/download-artifact@v5
+       - uses: actions/download-artifact@v6
          with:
            name: windows-latest-wheels
            path: artifacts/windows
-       - uses: actions/download-artifact@v5
+       - uses: actions/download-artifact@v6
          with:
            name: windows-11-arm-wheels
            path: artifacts/windows-arm64
-       - uses: actions/download-artifact@v5
+       - uses: actions/download-artifact@v6
          with:
            name: macos-latest-wheels
            path: artifacts/macos
-       - uses: actions/download-artifact@v5
+       - uses: actions/download-artifact@v6
          with:
            name: source-dist
            path: artifacts/sdist

--- a/.github/workflows/REUSABLE-wheeler.yaml
+++ b/.github/workflows/REUSABLE-wheeler.yaml
@@ -50,7 +50,7 @@ jobs:
          env:
            CIBW_ARCHS_WINDOWS: ARM64
 
-       - uses: actions/upload-artifact@v4
+       - uses: actions/upload-artifact@v5
          with:
            name: ${{matrix.os}}-wheels
            path: ./wheelhouse/*.whl
@@ -59,7 +59,7 @@ jobs:
      name: Build source dist
      runs-on: ubuntu-latest
      steps:
-       - uses: actions/setup-python@v5
+       - uses: actions/setup-python@v6
          with:
            python-version: '3.10'
        - uses: actions/checkout@v6
@@ -68,7 +68,7 @@ jobs:
        - name: Build sdist
          run: |
            python3 setup.py sdist
-       - uses: actions/upload-artifact@v4
+       - uses: actions/upload-artifact@v5
          with:
            name: source-dist
            path: ./dist/*.tar.gz
@@ -79,29 +79,29 @@ jobs:
      needs: ['build_wheels', 'build_sdist']
      runs-on: ubuntu-latest
      steps:
-       - uses: actions/setup-python@v5
+       - uses: actions/setup-python@v6
          with:
            python-version: '3.10'
        - name: Install tools
          run: |
            pip install twine wheel
-       - uses: actions/download-artifact@v4
+       - uses: actions/download-artifact@v5
          with:
            name: ubuntu-latest-wheels
            path: artifacts/linux
-       - uses: actions/download-artifact@v4
+       - uses: actions/download-artifact@v5
          with:
            name: windows-latest-wheels
            path: artifacts/windows
-       - uses: actions/download-artifact@v4
+       - uses: actions/download-artifact@v5
          with:
            name: windows-11-arm-wheels
            path: artifacts/windows-arm64
-       - uses: actions/download-artifact@v4
+       - uses: actions/download-artifact@v5
          with:
            name: macos-latest-wheels
            path: artifacts/macos
-       - uses: actions/download-artifact@v4
+       - uses: actions/download-artifact@v5
          with:
            name: source-dist
            path: artifacts/sdist

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Check Spelling
         uses: rojopolis/spellcheck-github-actions@0.33.1
         with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only changes; main impact is CI/release automation behavior if the new action versions or event gating differs from prior behavior.
> 
> **Overview**
> Updates CI workflows to newer GitHub Action major versions (notably `actions/*` v6 and `release-drafter` v7) to avoid deprecated Node runtimes.
> 
> Adjusts `release-drafter` to run only on `push` events and adds a separate PR-triggered `autolabel` job, switching authentication to the action `token` input instead of an `env` var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36024bde8cf255b8c01f4fbb837148890c83904d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->