### PR TITLE
Add free-threading support

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,7 @@ jobs:
      strategy:
        max-parallel: 15
        matrix:
-         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.15.0-alpha.7', 'pypy-3.9', 'pypy-3.10', 'pypy-3.11']
+         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.13t', '3.14', '3.14t', '3.15.0-alpha.7', 'pypy-3.9', 'pypy-3.10', 'pypy-3.11']
          os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
          include:
            - os: 'windows-11-arm'
@@ -57,6 +57,10 @@ jobs:
            pip install -r dev_requirements.txt
            python setup.py build_ext --inplace
            python -m pytest
+       - name: verify GIL stays disabled on free-threaded builds
+         if: ${{ endsWith(matrix.python-version, 't') }}
+         run: |
+           python -c "import sys, hiredis; assert not sys._is_gil_enabled(), 'importing hiredis re-enabled the GIL'"
        - name: run tests with assertions enabled
          if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
          run: |

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: 3.14',
+        'Programming Language :: Python :: Free Threading :: 2 - Beta',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Software Development',
     ],

--- a/src/hiredis.c
+++ b/src/hiredis.c
@@ -66,6 +66,13 @@ PyMODINIT_FUNC PyInit_hiredis(void)
 
     mod_hiredis = PyModule_Create(&hiredis_ModuleDef);
 
+#ifdef Py_GIL_DISABLED
+    /* Declare free-threading support. Per-Reader instance state is protected
+     * by a PyMutex; module-level state is set up here under the import lock
+     * and is read-only thereafter. */
+    PyUnstable_Module_SetGIL(mod_hiredis, Py_MOD_GIL_NOT_USED);
+#endif
+
     /* Setup custom exceptions */
     HIREDIS_STATE->HiErr_Base =
         PyErr_NewException(MOD_HIREDIS ".HiredisError", PyExc_Exception, NULL);

--- a/src/reader.c
+++ b/src/reader.c
@@ -408,7 +408,9 @@ static PyObject *Reader_feed(hiredis_ReaderObject *self, PyObject *args) {
       goto error;
     }
 
+    HIREDIS_READER_LOCK(self);
     redisReaderFeed(self->reader, (char *)buf.buf + off, len);
+    HIREDIS_READER_UNLOCK(self);
     PyBuffer_Release(&buf);
     Py_RETURN_NONE;
 
@@ -419,11 +421,14 @@ error:
 
 static PyObject *Reader_gets(hiredis_ReaderObject *self, PyObject *args) {
     PyObject *obj;
+    int shouldDecode = 1;
 
-    self->shouldDecode = 1;
-    if (!PyArg_ParseTuple(args, "|i", &self->shouldDecode)) {
+    if (!PyArg_ParseTuple(args, "|i", &shouldDecode)) {
         return NULL;
     }
+
+    HIREDIS_READER_LOCK(self);
+    self->shouldDecode = shouldDecode;
 
     if (redisReaderGetReply(self->reader, (void**)&obj) == REDIS_ERR) {
         PyObject *err = NULL;
@@ -443,23 +448,30 @@ static PyObject *Reader_gets(hiredis_ReaderObject *self, PyObject *args) {
             Py_DECREF(obj);
             Py_DECREF(err);
         }
+        HIREDIS_READER_UNLOCK(self);
         return NULL;
     }
 
     if (obj == NULL) {
         Py_INCREF(self->notEnoughDataObject);
-        return self->notEnoughDataObject;
+        PyObject *ret = self->notEnoughDataObject;
+        HIREDIS_READER_UNLOCK(self);
+        return ret;
     } else {
         /* Restore error when there is one. */
         if (self->error.ptype != NULL) {
             Py_DECREF(obj);
-            PyErr_Restore(self->error.ptype, self->error.pvalue,
-                    self->error.ptraceback);
+            PyObject *ptype = self->error.ptype;
+            PyObject *pvalue = self->error.pvalue;
+            PyObject *ptraceback = self->error.ptraceback;
             self->error.ptype = NULL;
             self->error.pvalue = NULL;
             self->error.ptraceback = NULL;
+            HIREDIS_READER_UNLOCK(self);
+            PyErr_Restore(ptype, pvalue, ptraceback);
             return NULL;
         }
+        HIREDIS_READER_UNLOCK(self);
         return obj;
     }
 }
@@ -478,22 +490,33 @@ static PyObject *Reader_setmaxbuf(hiredis_ReaderObject *self, PyObject *arg) {
             return NULL;
         }
     }
+    HIREDIS_READER_LOCK(self);
     self->reader->maxbuf = maxbuf;
+    HIREDIS_READER_UNLOCK(self);
 
     Py_INCREF(Py_None);
     return Py_None;
 }
 
 static PyObject *Reader_getmaxbuf(hiredis_ReaderObject *self) {
-    return PyLong_FromSize_t(self->reader->maxbuf);
+    HIREDIS_READER_LOCK(self);
+    size_t maxbuf = self->reader->maxbuf;
+    HIREDIS_READER_UNLOCK(self);
+    return PyLong_FromSize_t(maxbuf);
 }
 
 static PyObject *Reader_len(hiredis_ReaderObject *self) {
-    return PyLong_FromSize_t(self->reader->len);
+    HIREDIS_READER_LOCK(self);
+    size_t len = self->reader->len;
+    HIREDIS_READER_UNLOCK(self);
+    return PyLong_FromSize_t(len);
 }
 
 static PyObject *Reader_has_data(hiredis_ReaderObject *self) {
-    if(self->reader->pos < self->reader->len)
+    HIREDIS_READER_LOCK(self);
+    int has = self->reader->pos < self->reader->len;
+    HIREDIS_READER_UNLOCK(self);
+    if (has)
         Py_RETURN_TRUE;
     Py_RETURN_FALSE;
 }
@@ -506,7 +529,10 @@ static PyObject *Reader_set_encoding(hiredis_ReaderObject *self, PyObject *args,
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|zz", kwlist, &encoding, &errors))
         return NULL;
 
-    if(_Reader_set_encoding(self, encoding, errors) == -1)
+    HIREDIS_READER_LOCK(self);
+    int rc = _Reader_set_encoding(self, encoding, errors);
+    HIREDIS_READER_UNLOCK(self);
+    if (rc == -1)
         return NULL;
 
     Py_RETURN_NONE;

--- a/src/reader.c
+++ b/src/reader.c
@@ -296,10 +296,14 @@ static int _Reader_set_exception(PyObject **target, PyObject *value) {
     return 1;
 }
 
-static int _Reader_set_encoding(hiredis_ReaderObject *self, char *encoding, char *errors) {
+/* Validate encoding/errors without touching reader state. Runs arbitrary
+ * Python code (codec lookup machinery) and therefore must NOT be called
+ * while holding the per-Reader PyMutex — PyMutex is non-reentrant and a
+ * codec callback could otherwise deadlock by re-entering the same Reader. */
+static int _Reader_validate_encoding(char *encoding, char *errors) {
     PyObject *codecs, *result;
 
-    if (encoding) {  // validate that the encoding exists, raises LookupError if not
+    if (encoding) {
         codecs = PyImport_ImportModule("codecs");
         if (!codecs)
             return -1;
@@ -308,12 +312,9 @@ static int _Reader_set_encoding(hiredis_ReaderObject *self, char *encoding, char
         if (!result)
             return -1;
         Py_DECREF(result);
-        self->encoding = encoding;
-    } else {
-        self->encoding = NULL;
     }
 
-    if (errors) {   // validate that the error handler exists, raises LookupError if not
+    if (errors) {
         codecs = PyImport_ImportModule("codecs");
         if (!codecs)
             return -1;
@@ -322,12 +323,16 @@ static int _Reader_set_encoding(hiredis_ReaderObject *self, char *encoding, char
         if (!result)
             return -1;
         Py_DECREF(result);
-        self->errors = errors;
-    } else {
-        self->errors = "strict";
     }
 
     return 0;
+}
+
+/* Apply a previously-validated encoding pair. Must be called with the
+ * per-Reader lock held when the Reader is reachable from other threads. */
+static void _Reader_apply_encoding(hiredis_ReaderObject *self, char *encoding, char *errors) {
+    self->encoding = encoding;
+    self->errors = errors ? errors : "strict";
 }
 
 static int Reader_init(hiredis_ReaderObject *self, PyObject *args, PyObject *kwds) {
@@ -357,7 +362,12 @@ static int Reader_init(hiredis_ReaderObject *self, PyObject *args, PyObject *kwd
         Py_INCREF(self->notEnoughDataObject);
     }
 
-    return _Reader_set_encoding(self, encoding, errors);
+    /* The Reader is not yet published to other threads in __init__, so no
+     * lock is needed around the assignment. */
+    if (_Reader_validate_encoding(encoding, errors) < 0)
+        return -1;
+    _Reader_apply_encoding(self, encoding, errors);
+    return 0;
 }
 
 static PyObject *Reader_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
@@ -529,12 +539,15 @@ static PyObject *Reader_set_encoding(hiredis_ReaderObject *self, PyObject *args,
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|zz", kwlist, &encoding, &errors))
         return NULL;
 
-    HIREDIS_READER_LOCK(self);
-    int rc = _Reader_set_encoding(self, encoding, errors);
-    HIREDIS_READER_UNLOCK(self);
-    if (rc == -1)
+    /* Validate before taking the lock: the codec lookup runs arbitrary
+     * Python code, and PyMutex is non-reentrant. Short-circuits on the
+     * first failed lookup, matching the original behavior. */
+    if (_Reader_validate_encoding(encoding, errors) < 0)
         return NULL;
 
-    Py_RETURN_NONE;
+    HIREDIS_READER_LOCK(self);
+    _Reader_apply_encoding(self, encoding, errors);
+    HIREDIS_READER_UNLOCK(self);
 
+    Py_RETURN_NONE;
 }

--- a/src/reader.h
+++ b/src/reader.h
@@ -21,7 +21,22 @@ typedef struct {
         PyObject *pvalue;
         PyObject *ptraceback;
     } error;
+
+#ifdef Py_GIL_DISABLED
+    /* Per-instance mutex protecting reader state under free-threaded Python.
+     * Zero-initialized by tp_alloc and never deinitialized (PyMutex has no
+     * destructor). */
+    PyMutex lock;
+#endif
 } hiredis_ReaderObject;
+
+#ifdef Py_GIL_DISABLED
+#define HIREDIS_READER_LOCK(self)   PyMutex_Lock(&(self)->lock)
+#define HIREDIS_READER_UNLOCK(self) PyMutex_Unlock(&(self)->lock)
+#else
+#define HIREDIS_READER_LOCK(self)   ((void)0)
+#define HIREDIS_READER_UNLOCK(self) ((void)0)
+#endif
 
 typedef struct {
     PyListObject list;

--- a/tests/test_freethreading.py
+++ b/tests/test_freethreading.py
@@ -1,0 +1,227 @@
+"""Concurrency tests aimed at the free-threaded build.
+
+These also pass under the GIL build (where the GIL serializes everything).
+Under cp313t/cp314t with the GIL disabled they exercise the per-Reader
+PyMutex added for free-threading support.
+"""
+import sys
+import threading
+
+import pytest
+
+import hiredis
+
+
+def _run_in_threads(target, n_threads):
+    """Spawn n threads that all call target() with no arguments, releasing
+    from a barrier so they hit the test path concurrently. Returns any
+    exceptions raised on the worker threads."""
+    errors = []
+    barrier = threading.Barrier(n_threads)
+
+    def runner():
+        try:
+            barrier.wait()
+            target()
+        except BaseException as e:  # noqa: BLE001 - collect for the main thread
+            errors.append(e)
+
+    threads = [threading.Thread(target=runner) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return errors
+
+
+def test_gil_disabled_when_freethreaded():
+    """On a freethreaded interpreter, importing hiredis must not re-enable
+    the GIL. This is the contract of PyUnstable_Module_SetGIL."""
+    is_gil_enabled = getattr(sys, "_is_gil_enabled", None)
+    if is_gil_enabled is None:
+        pytest.skip("requires Python 3.13+")
+    if is_gil_enabled():
+        pytest.skip("not running on a freethreaded interpreter")
+    assert not is_gil_enabled()
+
+
+def test_concurrent_independent_readers():
+    """Each thread owns its own Reader. No shared mutable state, so every
+    thread must observe identical replies."""
+    payload = b"*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n"
+    iterations = 500
+
+    def worker():
+        for _ in range(iterations):
+            r = hiredis.Reader()
+            r.feed(payload)
+            reply = r.gets()
+            assert reply == [b"hello", b"world"]
+
+    errors = _run_in_threads(worker, n_threads=8)
+    assert not errors, errors
+
+
+def test_concurrent_shared_reader_atomic_feed_gets():
+    """Multiple threads share a single Reader. The protocol bytes for a
+    single command must not interleave across threads, so we hold a
+    Python-level lock around the feed+gets pair. The C-level PyMutex is
+    what protects the parser's internal state from being torn during each
+    individual call."""
+    cmd = b"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n"
+    iterations = 200
+    reader = hiredis.Reader()
+    serialize = threading.Lock()
+
+    def worker():
+        for _ in range(iterations):
+            with serialize:
+                reader.feed(cmd)
+                reply = reader.gets()
+            assert reply == [b"SET", b"key", b"value"]
+
+    errors = _run_in_threads(worker, n_threads=8)
+    assert not errors, errors
+
+
+def test_concurrent_shared_reader_no_crash_under_torn_protocol():
+    """Without a Python-level lock, concurrent feed() calls from different
+    threads can interleave bytes and produce protocol errors. The C-level
+    guarantee is: no crash, no UAF, no segfault. Acceptable outcomes per
+    call are a valid reply, the NotEnoughData sentinel, or a ProtocolError."""
+    chunks = [
+        b"*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n",
+        b"+OK\r\n",
+        b":42\r\n",
+        b"$5\r\nhello\r\n",
+    ]
+    iterations = 200
+    reader = hiredis.Reader()
+    n = 8
+    errors = []
+    barrier = threading.Barrier(n)
+
+    def worker(idx):
+        chunk = chunks[idx % len(chunks)]
+        for _ in range(iterations):
+            try:
+                reader.feed(chunk)
+            except (hiredis.ProtocolError, ValueError):
+                pass
+            try:
+                reader.gets()
+            except (hiredis.ProtocolError, hiredis.ReplyError):
+                pass
+
+    def runner(i):
+        try:
+            barrier.wait()
+            worker(i)
+        except BaseException as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=runner, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    for e in errors:
+        assert isinstance(e, (hiredis.ProtocolError, hiredis.ReplyError, ValueError)), e
+
+
+def test_concurrent_set_encoding_does_not_corrupt():
+    """set_encoding mutates instance state that gets() reads inside the
+    parser callbacks. Concurrent set_encoding from multiple threads followed
+    by feed+gets on the same Reader must not segfault."""
+    reader = hiredis.Reader()
+    encodings = ["utf-8", "latin-1", "ascii"]
+    iterations = 200
+    serialize = threading.Lock()
+
+    n = 8
+    errors = []
+    barrier = threading.Barrier(n)
+
+    def worker(idx):
+        for i in range(iterations):
+            reader.set_encoding(encodings[(idx + i) % len(encodings)])
+            with serialize:
+                reader.feed(b"+OK\r\n")
+                reader.gets()
+
+    def runner(i):
+        try:
+            barrier.wait()
+            worker(i)
+        except BaseException as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=runner, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, errors
+
+
+def test_concurrent_setmaxbuf_with_readers():
+    """setmaxbuf/getmaxbuf/len/has_data each touch self->reader internals.
+    Concurrent access from multiple threads must not crash."""
+    reader = hiredis.Reader()
+    iterations = 500
+
+    def setters():
+        for i in range(iterations):
+            reader.setmaxbuf((i + 1) * 1024)
+            _ = reader.getmaxbuf()
+
+    def readers():
+        for _ in range(iterations):
+            _ = reader.len()
+            _ = reader.has_data()
+
+    errors = _run_in_threads(setters, n_threads=4)
+    errors += _run_in_threads(readers, n_threads=4)
+    assert not errors, errors
+
+
+def test_concurrent_pack_command():
+    """pack_command is stateless — concurrent calls must produce identical
+    output and must not crash."""
+    args = ("HSET", "foo", "key", "value", "key2", b"value2", "key3", 67, "key4", 3.14)
+    expected = hiredis.pack_command(args)
+
+    def worker():
+        for _ in range(1000):
+            assert hiredis.pack_command(args) == expected
+
+    errors = _run_in_threads(worker, n_threads=8)
+    assert not errors, errors
+
+
+def test_concurrent_error_callbacks():
+    """User-supplied error classes are invoked from inside the parser
+    callbacks while the per-Reader lock is held. With one Reader per thread
+    they must produce isolated, correct results."""
+    calls = []
+    calls_lock = threading.Lock()
+
+    def make_error(msg):
+        with calls_lock:
+            calls.append(msg)
+        return RuntimeError(msg)
+
+    iterations = 100
+
+    def worker():
+        for _ in range(iterations):
+            r = hiredis.Reader(replyError=make_error)
+            r.feed(b"-ERR something went wrong\r\n")
+            reply = r.gets()
+            assert isinstance(reply, RuntimeError)
+
+    errors = _run_in_threads(worker, n_threads=8)
+    assert not errors, errors
+    assert len(calls) == 8 * iterations


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches C-extension parsing/state management to support free-threaded CPython, which can introduce subtle race/deadlock issues if locking is incorrect. CI adds new interpreter variants and targeted concurrency tests, reducing but not eliminating runtime risk.
> 
> **Overview**
> Adds explicit support for CPython free-threaded builds by declaring the module as GIL-independent (`PyUnstable_Module_SetGIL`) and protecting per-`Reader` mutable state with a per-instance `PyMutex` (`HIREDIS_READER_LOCK/UNLOCK`) around `feed`, `gets`, `setmaxbuf`, `getmaxbuf`, `len`, and `has_data`.
> 
> Refactors `set_encoding` handling to validate codec/error handlers *outside* the per-Reader mutex (avoiding non-reentrant deadlocks), then applies the settings under lock.
> 
> Expands CI to run on `3.13t`/`3.14t` and adds a guard that importing `hiredis` does not re-enable the GIL, plus a new `test_freethreading.py` suite with multi-threaded crash/race regression tests. Updates package classifiers to advertise free-threading beta support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 549aca68664f111fa44499ebd34c5297d7d9a582. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->