### PR TITLE
Fix benchmarking for hiredis-py

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -6,7 +6,7 @@ from redis import Redis
 
 import gevent
 from gevent import monkey
-from gevent.coros import Semaphore
+from gevent.lock import Semaphore
 monkey.patch_all()
 
 parser = optparse.OptionParser()
@@ -39,7 +39,7 @@ def run(clients):
   # Time how long it takes for all greenlets to finish
   join = partial(gevent.joinall, clients)
   time = timeit.timeit(join, number=1)
-  print "%.2f Kops" % ((len(commands) * count / 1000.0) / time)
+  print("%.2f Kops" % ((len(commands) * count / 1000.0) / time))
 
 # Let clients connect, and kickstart benchmark a little later
 clients = [gevent.spawn(create_client) for _ in range(options.clients)]


### PR DESCRIPTION
PR Description:

* This PR fixes the benchmark execution errors in hiredis-py.
* Replaced deprecated gevent imports with the current supported imports.
* Updated the benchmark scripts for Python 3 compatibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the benchmark script, updating a deprecated `gevent` import and modernizing output formatting.
> 
> **Overview**
> Fixes the `benchmark/benchmark.py` script to run on newer dependencies by switching `Semaphore` to `gevent.lock` (replacing deprecated `gevent.coros`).
> 
> Updates the benchmark output to use Python 3-compatible `print(...)` syntax.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9efb0155903d8b9dee1a2297abb7570fe605e3d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->